### PR TITLE
fixe CR broken as if issue is not passed as it is not mandatory

### DIFF
--- a/jenkins-ci/cr/scheduler.py
+++ b/jenkins-ci/cr/scheduler.py
@@ -57,6 +57,8 @@ def cifile_read(machine=''):
                 Testmachine = val
                 write_jenkinsfile(Testmachine)
             testline = 1
+        if len(value[0].split(',')) == 9:
+            print key[i]+'=None'
 
 
 datafile = open(jenkinsrun_file)


### PR DESCRIPTION
As issue is not a mandatory option so this patch address if issue number is
not given scheduler should add it as None value

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>