### PR TITLE
linuxci v2.1: update framework with latest python2 code 

### DIFF
--- a/jenkins-ci/scheduler.py
+++ b/jenkins-ci/scheduler.py
@@ -30,6 +30,7 @@ SID = ''
 sidfile = commonlib.base_path + SID + '/' + SID + '.json'
 date_str = datetime.datetime.now().strftime('%Y_%m_%d')
 date_obj = datetime.datetime.strptime(date_str, '%Y_%m_%d')
+TODAY = datetime.datetime.today().strftime('%A')
 
 def form_sid(sid, mailid, git, branch, tests, avtest):
     git = git.split('/')[-2]
@@ -194,37 +195,47 @@ def main():
         BRANCH = json_data['BRANCH']
         while not check_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST):
 
-            if LASTRUN is None:
-                if BUILDFREQ == 'daily':
-                    json_data['NEXTRUN'] = commonlib.oneday(date_str)
-                if BUILDFREQ == 'weekly':
-                    json_data['NEXTRUN'] = commonlib.oneweek(date_str)
-                if BUILDFREQ == 'monthly':
-                    json_data['NEXTRUN'] = commonlib.onemonth(date_obj)
-                update_datafile(SID, json_data)
-                print "always a candidate for Q"
-                add_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST)
-                if check_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST):
-                    print SID + " Job added to Queue succesfully !"
-            else:
-                lastrun = datetime.datetime.strptime(LASTRUN, '%Y_%m_%d')
-                if NEXTRUN is not None:
-                    nextrun = datetime.datetime.strptime(NEXTRUN, '%Y_%m_%d')
-                if lastrun > nextrun:
-                    json_data['LASTRUN'] = date_str
+            if 'day' in BUILDFREQ:
+                if LASTRUN is None or NEXTRUN is None:
+                    json_data['LASTRUN'] = json_data['NEXTRUN'] = BUILDFREQ
                     update_datafile(SID, json_data)
-                if nextrun <= date_obj and lastrun != date_obj:
-                    print "It is a candidate add for Q"
+                if BUILDFREQ == TODAY or NEXTRUN == TODAY :
                     add_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST)
                     if check_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST):
                         print SID + " Job added to Queue succesfully !"
+
+            else:
+                if LASTRUN is None:
                     if BUILDFREQ == 'daily':
-                        json_data['NEXTRUN'] = commonlib.oneday(LASTRUN)
+                        json_data['NEXTRUN'] = commonlib.oneday(date_str)
                     if BUILDFREQ == 'weekly':
-                        json_data['NEXTRUN'] = commonlib.oneweek(LASTRUN)
+                        json_data['NEXTRUN'] = commonlib.oneweek(date_str)
                     if BUILDFREQ == 'monthly':
-                        json_data['NEXTRUN'] = commonlib.onemonth(lastrun)
+                        json_data['NEXTRUN'] = commonlib.onemonth(date_obj)
                     update_datafile(SID, json_data)
+                    print "always a candidate for Q"
+                    add_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST)
+                    if check_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST):
+                        print SID + " Job added to Queue succesfully !"
+                else:
+                    lastrun = datetime.datetime.strptime(LASTRUN, '%Y_%m_%d')
+                    if NEXTRUN is not None:
+                        nextrun = datetime.datetime.strptime(NEXTRUN, '%Y_%m_%d')
+                    if lastrun > nextrun:
+                        json_data['LASTRUN'] = date_str
+                        update_datafile(SID, json_data)
+                    if nextrun <= date_obj and lastrun != date_obj:
+                        print "It is a candidate add for Q"
+                        add_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST)
+                        if check_job_inQ(SID, MAILID, GIT, BRANCH, TESTS, AVTEST):
+                            print SID + " Job added to Queue succesfully !"
+                        if BUILDFREQ == 'daily':
+                            json_data['NEXTRUN'] = commonlib.oneday(LASTRUN)
+                        if BUILDFREQ == 'weekly':
+                            json_data['NEXTRUN'] = commonlib.oneweek(LASTRUN)
+                        if BUILDFREQ == 'monthly':
+                            json_data['NEXTRUN'] = commonlib.onemonth(lastrun)
+                        update_datafile(SID, json_data)
             break
     print "\nList all jobs in Queue . . .  \n"
     print_Q()

--- a/jenkins-ci/subscription.py
+++ b/jenkins-ci/subscription.py
@@ -47,6 +47,9 @@ def create_sidfile(json_details, sid_file):
     sid_json['URL'] = json_details['git']
     sid_json['BRANCH'] = json_details['branch']
     sid_json['COMMITID'] = None
+    sid_json['GOOD'] = None
+    sid_json['BAD'] = None
+    sid_json['HEAD'] = None
     sid_json['LASTRUN'] = None
     sid_json['NEXTRUN'] = None
     sid_json['BUILDFREQ'] = json_details['build_freq']

--- a/lib/common_lib.py
+++ b/lib/common_lib.py
@@ -46,9 +46,10 @@ hostcopy_path = config_details.get('Details', 'hostcopy_path')
 subscribersfile = config_details.get('Details', 'subscribersfile')
 scp_timeout = int(config_details.get('Details', 'scp_timeout'))
 test_timeout = int(config_details.get('Details', 'test_timeout'))
+server = config_details.get('Details', 'server')
 
 # basic required pkgs, without this the run fails
-BASEPKG = ['git', 'telnet', 'rpm', 'python']
+BASEPKG = ['git', 'telnet', 'rpm', 'python', 'flex', 'bison']
 
 
 def get_output(cmd):
@@ -177,7 +178,7 @@ def read_json(path):
 
 
 def scp_to_host(file_path, host_details):
-    scp = pexpect.spawn('scp -l 8192 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r ' +
+    scp = pexpect.spawn('scp -l 8192 -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r ' +
                         file_path + ' ' + host_details['username'] + '@' + host_details['hostname'] + ':/root/')
     res = scp.expect([r'[Pp]assword:', pexpect.EOF])
     if res == 0:

--- a/lib/ipmi.py
+++ b/lib/ipmi.py
@@ -56,7 +56,7 @@ class ipmi:
 
     def bso_auth(self, console, username, password):
         time.sleep(2)
-        console.sendline('telnet 9.x.x.x.x')
+        console.sendline('telnet github.com')
         time.sleep(5)
         try:
             rc = console.expect(["Username:", "refused", "login:"], timeout=60)
@@ -89,8 +89,10 @@ class ipmi:
 
     def check_kernel_panic(self, console):
         list = [
-            "WARNING: CPU:", "kernel panic", "Aieee", "soft lockup", "not syncing", "Oops", "Bad trap at PC", "error:",
-            "Unable to handle kernel NULL pointer", "Unable to mount root device", "grub>", "grub rescue", "\(initramfs\)", pexpect.TIMEOUT]
+            "WARNING: CPU:", "kernel panic - not syncing:", "Aieee", "soft lockup", "Oops", "Bad trap at PC",
+            "Unable to handle kernel NULL pointer", "Unable to mount root device", "grub>", "grub rescue", "\(initramfs\)",
+            "Segfault", "Unable to handle paging request", "rcu_sched detected stalls", "NMI backtrace for cpu", "'Call Trace:",
+            "WARNING: at", "INFO: possible recursive locking detected", "Kernel BUG at", "double fault:",  pexpect.TIMEOUT]
         try:
             print "check_kernel_panic"
             rc = console.expect(list, timeout=200)
@@ -148,7 +150,7 @@ class ipmi:
     def activate(self):
         print "running:ipmitool -I lanplus %s -P %s  -H %s sol activate" % (self.user_name, self.password, self.host_name)
         con = pexpect.spawn('ipmitool -I lanplus %s -P %s -H %s sol activate' %
-                            (self.user_name, self.password, self.host_name), timeout=60)
+                            (self.user_name, self.password, self.host_name), timeout=300)
         return con
 
     def deactivate(self):
@@ -222,7 +224,7 @@ class ipmi:
                 else:
                     sys.exit(1)
             else:
-                console.expect(pexpect.TIMEOUT, timeout=30)
+                console.expect(pexpect.TIMEOUT, timeout=60)
                 print console.before
         except pexpect.ExceptionPexpect, e:
             console.sendcontrol("c")
@@ -238,7 +240,7 @@ class ipmi:
 
     def get_type(self, console):
         rc = console.expect_exact(
-            "[SOL Session operational.  Use ~? for help]\r\n", timeout=300)
+            "[SOL Session operational.  Use ~? for help]\r\n", timeout=600)
         if rc == 0:
             print "Got ipmi console : First run"
         else:
@@ -248,7 +250,7 @@ class ipmi:
         time.sleep(3)
         try:
             rc = console.expect(
-                ["\[.+\#", "petitboot", "login:", "(initramfs)"], timeout=400)
+                ["\[.+\#", "petitboot", "login:", "(initramfs)"], timeout=1400)
             if rc == 0:
                 rc_in = console.expect(
                     ["login:", pexpect.TIMEOUT], timeout=120)
@@ -277,7 +279,7 @@ class ipmi:
         if rc == 0:
             console.sendline(password)
             rc_l = console.expect(
-                ["Last login:", "incorrect", pexpect.TIMEOUT], timeout=300)
+                ["Last login:", "incorrect", pexpect.TIMEOUT], timeout=600)
             if rc_l == 1:
                 print "Error in logging.Wrong Credentials"
                 sys.exit(1)

--- a/lib/ssh.py
+++ b/lib/ssh.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# See LICENSE for more details.
+#
+# Copyright: 2019 IBM
+# Author: Abdul Haleem <abdhalee@linux.vnet.ibm.com>
+
+import os
+import sys
+import time
+import pexpect
+from pexpect import pxssh
+
+
+class ssh:
+
+    '''
+    This class contains the modules to perform various operations on an LPAR via ssh
+    The Host IP, username and password of host have to be passed to the class intially
+    while creating the object for the class.
+    '''
+
+    def __init__(self, ip, username, password):
+        self.host_ip = ip
+        self.user_name = username
+        self.password = password
+
+    def login(self):
+        '''
+        log in to lpar ssh
+        '''
+        if os.system('ping -c 2 ' + self.host_ip):
+            logging.error('Unable to ping remote test system!')
+            sys.exit(1)
+        else:
+            try:
+                self.ssh = pxssh.pxssh()
+                self.ssh.login(
+                    self.host_ip, self.user_name, self.password, login_timeout=60)
+                return self.ssh
+            except pxssh.ExceptionPxssh, e:
+                print "unable to ssh", str(e)
+                sys.exit(1)
+
+    def run_cmd(self, command, console, timeout=3000):
+        try:
+            console.sendline(command)
+            console.prompt(timeout=timeout)
+            time.sleep(0.5)
+            res = console.before
+            print res
+            console.sendline("echo $?")
+            console.prompt(timeout=3000)
+            time.sleep(0.5)
+            self.check = console.before
+            if("0" in self.check):
+                return res
+            else:
+                print "Command not executed successfully"
+        except Exception, info:
+            print info
+            sys.exit(1)


### PR DESCRIPTION
 Add SSH console support for running avocado tests over ssh
 postprocess.py : Run jobs on specific day
 ipmi.py: capture full trace, add new traces, more timeout
 hmc.py: add profile option, timeouts, more traces
 common_lib.py: Silence the progress bar, install deps
subscription.py: store good, bad commit id keys
Add per day subscription support for IO subscriptions
run_test.py: add ssh support, autokey verify, silence progress bar
